### PR TITLE
Enable int4range Support

### DIFF
--- a/src/epgsql_binary.erl
+++ b/src/epgsql_binary.erl
@@ -282,6 +282,7 @@ supports(cidr)        -> true;
 supports(inet)        -> true;
 supports(geometry)    -> true;
 supports(point)       -> true;
+supports(int4range)   -> true;
 supports({array, bool})   -> true;
 supports({array, int2})   -> true;
 supports({array, int4})   -> true;

--- a/test/epgsql_tests.erl
+++ b/test/epgsql_tests.erl
@@ -766,7 +766,7 @@ range_type_test(Module) ->
       Module,
       9.2,
       fun(_C) ->
-          check_type(Module, int4range, "int4range(10, 20)", <<"[10,20)">>,
+          check_type(Module, int4range, "int4range(10, 20)", {10,20},
                      [{1, 58}, {-1, 12}, {-985521, 5412687}, {minus_infinity, 0},
                       {984655, plus_infinity}, {minus_infinity, plus_infinity}])
       end,
@@ -916,22 +916,7 @@ compare(Type, V1 = {_, _, MS}, {D2, {H2, M2, S2}}) when Type == timestamp;
                                                         Type == timestamptz ->
     {D1, {H1, M1, S1}} = calendar:now_to_universal_time(V1),
     ({D1, H1, M1} =:= {D2, H2, M2}) and (abs(S1 + MS/1000000 - S2) < 0.000000000000001);
-compare(int4range, {Lower, Upper}, Result) ->
-  translate_infinities(Lower, Upper) =:= Result;
 compare(_Type, V1, V2)     -> V1 =:= V2.
-
-translate_infinities(Lower, Upper) ->
-  iolist_to_binary([lower(Lower), [","], upper(Upper)]).
-
-lower(minus_infinity) ->
-  "(";
-lower(Val) ->
-  io_lib:format("[~p", [Val]).
-
-upper(plus_infinity) ->
-  ")";
-upper(Val) ->
-  io_lib:format("~p)", [Val]).
 
 format_hstore({Hstore}) -> Hstore;
 format_hstore(Hstore) ->


### PR DESCRIPTION
The encode/decode funs for int4range were created but support for the type was never enabled. As such the tests were never actually run. This PR enables support and modifies the tests to properly parse the output of the underlying functions.
