### PR TITLE
Use `ssl_opts` for `ssl:connect()`

### DIFF
--- a/src/epgsql_sock.erl
+++ b/src/epgsql_sock.erl
@@ -315,7 +315,8 @@ start_ssl(S, Flag, Opts, State) ->
     {ok, <<Code>>} = gen_tcp:recv(S, 1, Timeout),
     case Code of
         $S  ->
-            case ssl:connect(S, Opts, Timeout) of
+            SslOpts = proplists:get_value(ssl_opts, Opts, []),
+            case ssl:connect(S, SslOpts, Timeout) of
                 {ok, S2}        -> State#state{mod = ssl, sock = S2};
                 {error, Reason} -> exit({ssl_negotiation_failed, Reason})
             end;


### PR DESCRIPTION
Pulling this commit from the upstream:

https://github.com/epgsql/epgsql/commit/d74ab908ef89927b7b8a67dd66797298b4d55870

Without this change, calling `epgsql:connect()` with `ssl: true` and `ssl_opts` would result in Postgresql responding with `invalid authorization specification`. I haven't dug into the internals, but this change (pulled from the upstream) fixes it.